### PR TITLE
fix: Removed predefine `maxLength` for Email text field in login page

### DIFF
--- a/lib/pages/setup/auth_page.dart
+++ b/lib/pages/setup/auth_page.dart
@@ -370,7 +370,6 @@ class _BasicAuthUIState extends State<BasicAuthUI> {
               store.email = value;
               store.error = null;
             },
-            maxLength: 32,
             maxLines: 1,
             autofillHints: const [AutofillHints.email],
             keyboardType: TextInputType.emailAddress,


### PR DESCRIPTION
- fixes: https://github.com/BirjuVachhani/target_mate/issues/6